### PR TITLE
add stdout option on cd command to evaluate via backticks

### DIFF
--- a/line.go
+++ b/line.go
@@ -45,6 +45,18 @@ func (l *Line) read(line string) {
 	}
 }
 
+// Execute cmd or print to stdout
+func (l *Line) dispatch() error {
+	if strings.HasPrefix(l.cmd, "cd ") {
+		fmt.Fprint(os.Stdout, l.cmd[3:len(l.cmd)])
+	} else {
+		// Not a change directory
+		l.execute()
+	}
+	
+	return nil
+}
+
 func (l *Line) execute() error {
 	// Replace the current process with the cmd.
 	cmdParts := strings.Split(l.cmd, " ")

--- a/rem.go
+++ b/rem.go
@@ -56,13 +56,13 @@ func (r *Rem) executeIndex(index int) error {
 	if err != nil {
 		return err
 	}
-	return line.execute()
+	return line.dispatch()
 }
 
 func (r *Rem) executeTag(tag string) error {
 	for _, line := range r.lines {
 		if line.tag == tag {
-			return line.execute()
+			return line.dispatch()
 		}
 	}
 	return errors.New("Tag not found.")


### PR DESCRIPTION
Issuing `rem add cd /foo` and subsequently `rem {index}` on that command simply prints the path without the `cd` to stdout, making it easy to evaluate via backticks. To expand on this, I could parse for any disallowed commands like chains `&&`, containing `env` variables and print all of those to stdout, sanitized or not? 
